### PR TITLE
fix: 修复无法在 Chrome 110 以下版本无法使用的bug

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -38,9 +38,6 @@ chrome.webNavigation.onCompleted.addListener((details) => {
         tabId: details.tabId,
         text: 'on'
       });
-      chrome.action.setBadgeTextColor({
-        color: 'white'
-      });
       chrome.scripting.executeScript({
         target: { tabId: details.tabId },
         world: 'MAIN',


### PR DESCRIPTION
api chrome.action.setBadgeTextColor 在 Chrome 110+版本才支持，在使用 Chrome 109 （win7最后的版本）时，该 api 导致插件报错，无法完成插件初始化，导致插件无法使用，badgeTextColor 默认为白色，无需使用此 api 设置，故删除该代码