### PR TITLE
fix: 修复插件配置的server address包含子路径时，注入的api路径不正确的问题

### DIFF
--- a/background/index.ts
+++ b/background/index.ts
@@ -93,8 +93,9 @@ async function handleInjectPageSpy(data: { url: string; tabId: number }) {
                 const scheme = userCfg.enableSSL ? 'https://' : 'http://';
                 if (serviceAddress) {
                   const url = new URL(`${scheme}${serviceAddress}`);
-                  userCfg.api = url.pathname.endsWith("/") ? `${url.host}${url.pathname.slice(0,-1)}` : `${url.host}${url.pathname}`;
-                  userCfg.clientOrigin = url.origin;
+                  const address = url.pathname.endsWith("/") ? `${url.host}${url.pathname.slice(0,-1)}` : `${url.host}${url.pathname}`;
+                  userCfg.api = address;
+                  userCfg.clientOrigin = `${scheme}${address}`;
                 }
 
                 window.$harbor = new window.DataHarborPlugin();


### PR DESCRIPTION
修复插件配置的server address包含自路径时，注入的api路径不正确的问题
https://github.com/HuolalaTech/page-spy-web/issues/323